### PR TITLE
proxy: improve http proxy settings

### DIFF
--- a/DSM.sh
+++ b/DSM.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# Current Version: 1.0.3
-
 ## How to get and use?
 # curl "https://source.zhijie.online/AutoDeploy/main/DSM.sh" | sudo bash
 # wget -qO- "https://source.zhijie.online/AutoDeploy/main/DSM.sh" | sudo bash
@@ -119,7 +117,8 @@ function ConfigurePackages() {
             done
         }
         function GenerateOMZProfile() {
-            PROXY_AUTH=""
+            PROXY_URL="http://vpn.zhijie.online:7890" # http://username:password@ip:port
+
             omz_list=(
                 "export DEBIAN_FRONTEND=\"noninteractive\""
                 "export EDITOR=\"nano\""
@@ -128,7 +127,7 @@ function ConfigurePackages() {
                 "# export SSH_AUTH_SOCK=\"\$(gpgconf --list-dirs agent-ssh-socket)\" && gpgconf --launch gpg-agent && gpg-connect-agent updatestartuptty /bye > \"/dev/null\" 2>&1"
                 "export ZSH=\"\$HOME/.oh-my-zsh\""
                 "function proxy_off(){ unset all_proxy; unset ftp_proxy; unset http_proxy; unset https_proxy; unset rsync_proxy }"
-                "function proxy_on(){ export all_proxy=\"socks5://${PROXY_AUTH:+${PROXY_AUTH}@}vpn.zhijie.online:7890\"; export ftp_proxy=\"http://${PROXY_AUTH:+${PROXY_AUTH}@}vpn.zhijie.online:7890\"; export http_proxy=\"http://${PROXY_AUTH:+${PROXY_AUTH}@}vpn.zhijie.online:7890\"; export https_proxy=\"http://${PROXY_AUTH:+${PROXY_AUTH}@}vpn.zhijie.online:7890\"; export rsync_proxy=\"http://${PROXY_AUTH:+${PROXY_AUTH}@}vpn.zhijie.online:7890\" }"
+                "function proxy_on(){ export all_proxy=\"${PROXY_URL}\"; export ftp_proxy=\"${PROXY_URL}\"; export http_proxy=\"${PROXY_URL}\"; export https_proxy=\"${PROXY_URL}\"; export rsync_proxy=\"${PROXY_URL}\" }"
                 "plugins=(zsh-autosuggestions zsh-completions zsh-history-substring-search zsh-syntax-highlighting)"
                 "ZSH_CACHE_DIR=\"\$ZSH/cache\""
                 "ZSH_CUSTOM=\"\$ZSH/custom\""

--- a/DSM.sh
+++ b/DSM.sh
@@ -117,7 +117,7 @@ function ConfigurePackages() {
             done
         }
         function GenerateOMZProfile() {
-            PROXY_URL="http://vpn.zhijie.online:7890" # http://username:password@ip:port
+            PROXY_URL='http://vpn.zhijie.online:7890' # http://username:password@ip:port
 
             omz_list=(
                 "export DEBIAN_FRONTEND=\"noninteractive\""

--- a/DSM.sh
+++ b/DSM.sh
@@ -118,6 +118,7 @@ function ConfigurePackages() {
         }
         function GenerateOMZProfile() {
             PROXY_URL='http://vpn.zhijie.online:7890' # http://username:password@ip:port
+            NO_PROXY='localhost,127.0.0.1,::1'
 
             omz_list=(
                 "export DEBIAN_FRONTEND=\"noninteractive\""
@@ -126,8 +127,8 @@ function ConfigurePackages() {
                 "export PATH=\"${DEFAULT_PATH}:\$PATH\""
                 "# export SSH_AUTH_SOCK=\"\$(gpgconf --list-dirs agent-ssh-socket)\" && gpgconf --launch gpg-agent && gpg-connect-agent updatestartuptty /bye > \"/dev/null\" 2>&1"
                 "export ZSH=\"\$HOME/.oh-my-zsh\""
-                "function proxy_off(){ unset all_proxy; unset ftp_proxy; unset http_proxy; unset https_proxy; unset rsync_proxy }"
-                "function proxy_on(){ export all_proxy=\"${PROXY_URL}\"; export ftp_proxy=\"${PROXY_URL}\"; export http_proxy=\"${PROXY_URL}\"; export https_proxy=\"${PROXY_URL}\"; export rsync_proxy=\"${PROXY_URL}\" }"
+                "function proxy_off(){ unset all_proxy; unset ftp_proxy; unset http_proxy; unset https_proxy; unset rsync_proxy; unset no_proxy }"
+                "function proxy_on(){ export all_proxy=\"${PROXY_URL}\"; export ftp_proxy=\"${PROXY_URL}\"; export http_proxy=\"${PROXY_URL}\"; export https_proxy=\"${PROXY_URL}\"; export rsync_proxy=\"${PROXY_URL}\"; export no_proxy=\"${NO_PROXY}\" }"
                 "plugins=(zsh-autosuggestions zsh-completions zsh-history-substring-search zsh-syntax-highlighting)"
                 "ZSH_CACHE_DIR=\"\$ZSH/cache\""
                 "ZSH_CUSTOM=\"\$ZSH/custom\""

--- a/ProxmoxVE.sh
+++ b/ProxmoxVE.sh
@@ -726,7 +726,7 @@ function ConfigurePackages() {
             'tcp_connect_time_out 8000'
             'tcp_read_time_out 15000'
             '[ProxyList]'
-            "${PROXY_PROTOCOL:-http} ${PROXY_IP:-127.0.0.1} ${PROXY_PORT:-7890} ${PROXY_USERNAME} ${PROXY_PASSWORD}"
+            "${PROXY_PROTOCOL:-socks5} ${PROXY_IP:-127.0.0.1} ${PROXY_PORT:-7891} ${PROXY_USERNAME} ${PROXY_PASSWORD}"
         )
 
         if [ -f "/etc/proxychains4.conf" ]; then

--- a/ProxmoxVE.sh
+++ b/ProxmoxVE.sh
@@ -990,7 +990,7 @@ function ConfigurePackages() {
             done
         }
         function GenerateOMZProfile() {
-            PROXY_URL="http://vpn.zhijie.online:7890" # http://username:password@ip:port
+            PROXY_URL='http://vpn.zhijie.online:7890' # http://username:password@ip:port
 
             omz_list=(
                 "export DEBIAN_FRONTEND=\"noninteractive\""

--- a/ProxmoxVE.sh
+++ b/ProxmoxVE.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# Current Version: 4.6.9
-
 ## How to get and use?
 # curl "https://source.zhijie.online/AutoDeploy/main/ProxmoxVE.sh" | sudo bash
 # wget -qO- "https://source.zhijie.online/AutoDeploy/main/ProxmoxVE.sh" | sudo bash
@@ -992,7 +990,8 @@ function ConfigurePackages() {
             done
         }
         function GenerateOMZProfile() {
-            PROXY_AUTH=""
+            PROXY_URL="http://vpn.zhijie.online:7890" # http://username:password@ip:port
+
             omz_list=(
                 "export DEBIAN_FRONTEND=\"noninteractive\""
                 "export EDITOR=\"nano\""
@@ -1001,7 +1000,7 @@ function ConfigurePackages() {
                 "# export SSH_AUTH_SOCK=\"\$(gpgconf --list-dirs agent-ssh-socket)\" && gpgconf --launch gpg-agent && gpg-connect-agent updatestartuptty /bye > \"/dev/null\" 2>&1"
                 "export ZSH=\"\$HOME/.oh-my-zsh\""
                 "function proxy_off(){ unset all_proxy; unset ftp_proxy; unset http_proxy; unset https_proxy; unset rsync_proxy }"
-                "function proxy_on(){ export all_proxy=\"socks5://${PROXY_AUTH:+${PROXY_AUTH}@}vpn.zhijie.online:7890\"; export ftp_proxy=\"http://${PROXY_AUTH:+${PROXY_AUTH}@}vpn.zhijie.online:7890\"; export http_proxy=\"http://${PROXY_AUTH:+${PROXY_AUTH}@}vpn.zhijie.online:7890\"; export https_proxy=\"http://${PROXY_AUTH:+${PROXY_AUTH}@}vpn.zhijie.online:7890\"; export rsync_proxy=\"http://${PROXY_AUTH:+${PROXY_AUTH}@}vpn.zhijie.online:7890\" }"
+                "function proxy_on(){ export all_proxy=\"${PROXY_URL}\"; export ftp_proxy=\"${PROXY_URL}\"; export http_proxy=\"${PROXY_URL}\"; export https_proxy=\"${PROXY_URL}\"; export rsync_proxy=\"${PROXY_URL}\" }"
                 "plugins=(zsh-autosuggestions zsh-completions zsh-history-substring-search zsh-syntax-highlighting)"
                 "ZSH_CACHE_DIR=\"\$ZSH/cache\""
                 "ZSH_CUSTOM=\"\$ZSH/custom\""

--- a/ProxmoxVE.sh
+++ b/ProxmoxVE.sh
@@ -726,7 +726,7 @@ function ConfigurePackages() {
             'tcp_connect_time_out 8000'
             'tcp_read_time_out 15000'
             '[ProxyList]'
-            "${PROXY_PROTOCOL:-socks5} ${PROXY_IP:-127.0.0.1} ${PROXY_PORT:-7890} ${PROXY_USERNAME} ${PROXY_PASSWORD}"
+            "${PROXY_PROTOCOL:-http} ${PROXY_IP:-127.0.0.1} ${PROXY_PORT:-7890} ${PROXY_USERNAME} ${PROXY_PASSWORD}"
         )
 
         if [ -f "/etc/proxychains4.conf" ]; then
@@ -991,6 +991,7 @@ function ConfigurePackages() {
         }
         function GenerateOMZProfile() {
             PROXY_URL='http://vpn.zhijie.online:7890' # http://username:password@ip:port
+            NO_PROXY='localhost,127.0.0.1,::1'
 
             omz_list=(
                 "export DEBIAN_FRONTEND=\"noninteractive\""
@@ -999,8 +1000,8 @@ function ConfigurePackages() {
                 "export PATH=\"${DEFAULT_PATH}:\$PATH\""
                 "# export SSH_AUTH_SOCK=\"\$(gpgconf --list-dirs agent-ssh-socket)\" && gpgconf --launch gpg-agent && gpg-connect-agent updatestartuptty /bye > \"/dev/null\" 2>&1"
                 "export ZSH=\"\$HOME/.oh-my-zsh\""
-                "function proxy_off(){ unset all_proxy; unset ftp_proxy; unset http_proxy; unset https_proxy; unset rsync_proxy }"
-                "function proxy_on(){ export all_proxy=\"${PROXY_URL}\"; export ftp_proxy=\"${PROXY_URL}\"; export http_proxy=\"${PROXY_URL}\"; export https_proxy=\"${PROXY_URL}\"; export rsync_proxy=\"${PROXY_URL}\" }"
+                "function proxy_off(){ unset all_proxy; unset ftp_proxy; unset http_proxy; unset https_proxy; unset rsync_proxy; unset no_proxy }"
+                "function proxy_on(){ export all_proxy=\"${PROXY_URL}\"; export ftp_proxy=\"${PROXY_URL}\"; export http_proxy=\"${PROXY_URL}\"; export https_proxy=\"${PROXY_URL}\"; export rsync_proxy=\"${PROXY_URL}\"; export no_proxy=\"${NO_PROXY}\" }"
                 "plugins=(zsh-autosuggestions zsh-completions zsh-history-substring-search zsh-syntax-highlighting)"
                 "ZSH_CACHE_DIR=\"\$ZSH/cache\""
                 "ZSH_CUSTOM=\"\$ZSH/custom\""

--- a/Ubuntu.sh
+++ b/Ubuntu.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# Current Version: 6.2.1
-
 ## How to get and use?
 # curl "https://source.zhijie.online/AutoDeploy/main/Ubuntu.sh" | sudo bash
 # wget -qO- "https://source.zhijie.online/AutoDeploy/main/Ubuntu.sh" | sudo bash
@@ -1030,7 +1028,8 @@ function ConfigurePackages() {
             done
         }
         function GenerateOMZProfile() {
-            PROXY_AUTH=""
+            PROXY_URL="http://vpn.zhijie.online:7890" # http://username:password@ip:port
+
             omz_list=(
                 "export DEBIAN_FRONTEND=\"noninteractive\""
                 "export EDITOR=\"nano\""
@@ -1039,7 +1038,7 @@ function ConfigurePackages() {
                 "# export SSH_AUTH_SOCK=\"\$(gpgconf --list-dirs agent-ssh-socket)\" && gpgconf --launch gpg-agent && gpg-connect-agent updatestartuptty /bye > \"/dev/null\" 2>&1"
                 "export ZSH=\"\$HOME/.oh-my-zsh\""
                 "function proxy_off(){ unset all_proxy; unset ftp_proxy; unset http_proxy; unset https_proxy; unset rsync_proxy }"
-                "function proxy_on(){ export all_proxy=\"socks5://${PROXY_AUTH:+${PROXY_AUTH}@}vpn.zhijie.online:7890\"; export ftp_proxy=\"http://${PROXY_AUTH:+${PROXY_AUTH}@}vpn.zhijie.online:7890\"; export http_proxy=\"http://${PROXY_AUTH:+${PROXY_AUTH}@}vpn.zhijie.online:7890\"; export https_proxy=\"http://${PROXY_AUTH:+${PROXY_AUTH}@}vpn.zhijie.online:7890\"; export rsync_proxy=\"http://${PROXY_AUTH:+${PROXY_AUTH}@}vpn.zhijie.online:7890\" }"
+                "function proxy_on(){ export all_proxy=\"${PROXY_URL}\"; export ftp_proxy=\"${PROXY_URL}\"; export http_proxy=\"${PROXY_URL}\"; export https_proxy=\"${PROXY_URL}\"; export rsync_proxy=\"${PROXY_URL}\" }"
                 "plugins=(zsh-autosuggestions zsh-completions zsh-history-substring-search zsh-syntax-highlighting)"
                 "ZSH_CACHE_DIR=\"\$ZSH/cache\""
                 "ZSH_CUSTOM=\"\$ZSH/custom\""

--- a/Ubuntu.sh
+++ b/Ubuntu.sh
@@ -782,7 +782,7 @@ function ConfigurePackages() {
             'tcp_connect_time_out 8000'
             'tcp_read_time_out 15000'
             '[ProxyList]'
-            "${PROXY_PROTOCOL:-socks5} ${PROXY_IP:-127.0.0.1} ${PROXY_PORT:-7890} ${PROXY_USERNAME} ${PROXY_PASSWORD}"
+            "${PROXY_PROTOCOL:-http} ${PROXY_IP:-127.0.0.1} ${PROXY_PORT:-7890} ${PROXY_USERNAME} ${PROXY_PASSWORD}"
         )
 
         if [ -f "/etc/proxychains4.conf" ]; then
@@ -1029,6 +1029,7 @@ function ConfigurePackages() {
         }
         function GenerateOMZProfile() {
             PROXY_URL='http://vpn.zhijie.online:7890' # http://username:password@ip:port
+            NO_PROXY='localhost,127.0.0.1,::1'
 
             omz_list=(
                 "export DEBIAN_FRONTEND=\"noninteractive\""
@@ -1037,8 +1038,8 @@ function ConfigurePackages() {
                 "export PATH=\"${DEFAULT_PATH}:\$PATH\""
                 "# export SSH_AUTH_SOCK=\"\$(gpgconf --list-dirs agent-ssh-socket)\" && gpgconf --launch gpg-agent && gpg-connect-agent updatestartuptty /bye > \"/dev/null\" 2>&1"
                 "export ZSH=\"\$HOME/.oh-my-zsh\""
-                "function proxy_off(){ unset all_proxy; unset ftp_proxy; unset http_proxy; unset https_proxy; unset rsync_proxy }"
-                "function proxy_on(){ export all_proxy=\"${PROXY_URL}\"; export ftp_proxy=\"${PROXY_URL}\"; export http_proxy=\"${PROXY_URL}\"; export https_proxy=\"${PROXY_URL}\"; export rsync_proxy=\"${PROXY_URL}\" }"
+                "function proxy_off(){ unset all_proxy; unset ftp_proxy; unset http_proxy; unset https_proxy; unset rsync_proxy; unset no_proxy }"
+                "function proxy_on(){ export all_proxy=\"${PROXY_URL}\"; export ftp_proxy=\"${PROXY_URL}\"; export http_proxy=\"${PROXY_URL}\"; export https_proxy=\"${PROXY_URL}\"; export rsync_proxy=\"${PROXY_URL}\"; export no_proxy=\"${NO_PROXY}\" }"
                 "plugins=(zsh-autosuggestions zsh-completions zsh-history-substring-search zsh-syntax-highlighting)"
                 "ZSH_CACHE_DIR=\"\$ZSH/cache\""
                 "ZSH_CUSTOM=\"\$ZSH/custom\""

--- a/Ubuntu.sh
+++ b/Ubuntu.sh
@@ -782,7 +782,7 @@ function ConfigurePackages() {
             'tcp_connect_time_out 8000'
             'tcp_read_time_out 15000'
             '[ProxyList]'
-            "${PROXY_PROTOCOL:-http} ${PROXY_IP:-127.0.0.1} ${PROXY_PORT:-7890} ${PROXY_USERNAME} ${PROXY_PASSWORD}"
+            "${PROXY_PROTOCOL:-socks5} ${PROXY_IP:-127.0.0.1} ${PROXY_PORT:-7891} ${PROXY_USERNAME} ${PROXY_PASSWORD}"
         )
 
         if [ -f "/etc/proxychains4.conf" ]; then

--- a/Ubuntu.sh
+++ b/Ubuntu.sh
@@ -1028,7 +1028,7 @@ function ConfigurePackages() {
             done
         }
         function GenerateOMZProfile() {
-            PROXY_URL="http://vpn.zhijie.online:7890" # http://username:password@ip:port
+            PROXY_URL='http://vpn.zhijie.online:7890' # http://username:password@ip:port
 
             omz_list=(
                 "export DEBIAN_FRONTEND=\"noninteractive\""


### PR DESCRIPTION
## Summary by Sourcery

在 ProxmoxVE、Ubuntu 和 DSM 部署脚本中标准化并简化 HTTP 代理配置。

改进内容：
- 在 ProxmoxVE 和 Ubuntu 脚本中，将 proxychains 默认 SOCKS5 端口从 7890 更新为 7891。
- 统一 oh-my-zsh 代理辅助函数，使其使用单一的 HTTP 代理 URL 和 NO_PROXY 列表，确保在所有脚本中以一致的方式设置和清理环境变量。
- 从 shell 脚本中移除过时的内联版本注释，以避免手动维护导致的版本偏差。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize and simplify HTTP proxy configuration across ProxmoxVE, Ubuntu, and DSM deployment scripts.

Enhancements:
- Update proxychains default SOCKS5 port from 7890 to 7891 in ProxmoxVE and Ubuntu scripts.
- Unify oh-my-zsh proxy helper functions to use a single HTTP proxy URL and NO_PROXY list, ensuring consistent environment variable setup and teardown across all scripts.
- Remove outdated inline version comments from the shell scripts to avoid manual version drift.

</details>