### PR TITLE
feat: remove history after exit

### DIFF
--- a/DSM.sh
+++ b/DSM.sh
@@ -152,6 +152,7 @@ function ConfigurePackages() {
                 "ZSH_AUTOSUGGEST_STRATEGY=(match_prev_cmd history completion)"
                 "ZSH_AUTOSUGGEST_USE_ASYNC=\"true\""
                 "source \"\$ZSH/oh-my-zsh.sh\""
+                'TRAPEXIT() { rm -rf ~/.zsh_history(N) ~/.ssh/known_hosts*(N) }'
             )
             which "zsh" > "/dev/null" 2>&1
             if [ "$?" -eq "0" ] && [ -d "/var/services/homes/${CurrentUsername}/.oh-my-zsh" ]; then

--- a/ProxmoxVE.sh
+++ b/ProxmoxVE.sh
@@ -267,7 +267,6 @@ function ConfigurePackages() {
         crontab_list=(
             "0 0 * * 7 sudo apt update && sudo apt full-upgrade -qy && sudo apt autoremove -qy --purge"
             "# 0 4 * * 7 sudo reboot"
-            "@reboot sudo rm -rf /root/.*_history /root/.ssh/known_hosts*"
         )
         which "crontab" > "/dev/null" 2>&1
         if [ "$?" -eq "0" ]; then
@@ -1010,6 +1009,7 @@ function ConfigurePackages() {
                 "ZSH_AUTOSUGGEST_STRATEGY=(match_prev_cmd history completion)"
                 "ZSH_AUTOSUGGEST_USE_ASYNC=\"true\""
                 "source \"\$ZSH/oh-my-zsh.sh\""
+                'TRAPEXIT() { rm -rf ~/.zsh_history(N) ~/.ssh/known_hosts*(N) }'
             )
             which "zsh" > "/dev/null" 2>&1
             if [ "$?" -eq "0" ] && [ -d "/etc/zsh/oh-my-zsh" ]; then
@@ -1070,9 +1070,7 @@ function ConfigureSystem() {
         DEFAULT_FULLNAME="${DEFAULT_LASTNAME} ${DEFAULT_FIRSTNAME}"
         DEFAULT_USERNAME="proxmox"
         DEFAULT_PASSWORD='*Proxmox123*'
-        crontab_list=(
-            "@reboot rm -rf /home/${DEFAULT_USERNAME}/.*_history /home/${DEFAULT_USERNAME}/.ssh/known_hosts*"
-        )
+        crontab_list=()
         if [ -d "/home" ]; then
             USER_LIST=($(ls "/home" | grep -v "${DEFAULT_USERNAME}" | awk "{print $2}") ${DEFAULT_USERNAME})
         else

--- a/Ubuntu.sh
+++ b/Ubuntu.sh
@@ -324,7 +324,6 @@ function ConfigurePackages() {
         crontab_list=(
             "0 0 * * 7 sudo apt update && sudo apt full-upgrade -qy && sudo apt autoremove -qy --purge"
             "# 0 4 * * 7 sudo reboot"
-            "@reboot sudo rm -rf /root/.*_history /root/.ssh/known_hosts*"
         )
         which "crontab" > "/dev/null" 2>&1
         if [ "$?" -eq "0" ]; then
@@ -1026,6 +1025,7 @@ function ConfigurePackages() {
                 "ZSH_AUTOSUGGEST_STRATEGY=(match_prev_cmd history completion)"
                 "ZSH_AUTOSUGGEST_USE_ASYNC=\"true\""
                 "source \"\$ZSH/oh-my-zsh.sh\""
+                'TRAPEXIT() { rm -rf ~/.zsh_history(N) ~/.ssh/known_hosts*(N) }'
             )
             which "zsh" > "/dev/null" 2>&1
             if [ "$?" -eq "0" ] && [ -d "/etc/zsh/oh-my-zsh" ]; then
@@ -1086,9 +1086,7 @@ function ConfigureSystem() {
         DEFAULT_FULLNAME="${DEFAULT_LASTNAME} ${DEFAULT_FIRSTNAME}"
         DEFAULT_USERNAME="ubuntu"
         DEFAULT_PASSWORD='*Ubuntu123*'
-        crontab_list=(
-            "@reboot rm -rf /home/${DEFAULT_USERNAME}/.*_history /home/${DEFAULT_USERNAME}/.ssh/known_hosts*"
-        )
+        crontab_list=()
         if [ -d "/home" ]; then
             USER_LIST=($(ls "/home" | grep -v "${DEFAULT_USERNAME}" | awk "{print $2}") ${DEFAULT_USERNAME})
         else

--- a/macOS.sh
+++ b/macOS.sh
@@ -36,15 +36,7 @@ function GetSystemInformation() {
 # Configure Packages
 function ConfigurePackages() {
     function ConfigureCrontab() {
-        which "ollama" > "/dev/null" 2>&1
-        if [ "$?" -eq "1" ]; then
-            OLLAMA_ENV_SETUP="@reboot launchctl setenv OLLAMA_HOST '0.0.0.0' && launchctl setenv OLLAMA_ORIGINS '*'"
-        fi
-
-        crontab_list=(
-            "@reboot rm -rf /Users/${CurrentUsername}/.*_history /Users/${CurrentUsername}/.ssh/known_hosts*"
-            "$OLLAMA_ENV_SETUP"
-        )
+        crontab_list=()
         which "crontab" > "/dev/null" 2>&1
         if [ "$?" -eq "0" ]; then
             rm -rf "/tmp/crontab.autodeploy" && for crontab_list_task in "${!crontab_list[@]}"; do
@@ -293,6 +285,7 @@ function ConfigurePackages() {
                 "ZSH_AUTOSUGGEST_STRATEGY=(match_prev_cmd history completion)"
                 "ZSH_AUTOSUGGEST_USE_ASYNC=\"true\""
                 "source \"\$ZSH/oh-my-zsh.sh\""
+                'TRAPEXIT() { rm -rf ~/.zsh_history(N) ~/.ssh/known_hosts*(N) }'
             )
             which "zsh" > "/dev/null" 2>&1
             if [ "$?" -eq "0" ] && [ -d "/Users/${CurrentUsername}/.oh-my-zsh" ]; then


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

移除启动时执行清理的 cron 任务，改为在每个 shell 退出时按会话清理历史记录和 SSH known_hosts。

新特性：
- 添加 zsh 的 `TRAPEXIT` 钩子，在受支持的平台上，当 shell 退出时删除当前用户的 zsh 历史记录和 SSH known_hosts 文件。

改进：
- 移除之前在 macOS、Proxmox VE 和 Ubuntu 上为 root 和默认用户配置的 `@reboot` crontab 条目，这些条目会在启动时删除历史记录和 SSH known_hosts。
- 从 macOS 的 crontab 配置中移除有条件的 Ollama 环境设置，以简化启动配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove boot-time cleanup cron jobs and switch to per-shell cleanup of history and SSH known_hosts on exit.

New Features:
- Add a zsh TRAPEXIT hook to delete the current user's zsh history and SSH known_hosts files when the shell exits on supported platforms.

Enhancements:
- Remove previously configured @reboot crontab entries that deleted history and SSH known_hosts for root and default users on macOS, Proxmox VE, and Ubuntu.
- Drop conditional Ollama environment setup from the macOS crontab configuration to simplify startup configuration.

</details>