### PR TITLE
chore: update crontab list

### DIFF
--- a/ProxmoxVE.sh
+++ b/ProxmoxVE.sh
@@ -267,6 +267,7 @@ function ConfigurePackages() {
         crontab_list=(
             "0 0 * * 7 sudo apt update && sudo apt full-upgrade -qy && sudo apt autoremove -qy --purge"
             "# 0 4 * * 7 sudo reboot"
+            "@reboot sudo rm -rf ~/.*_history ~/.ssh/known_hosts*"
         )
         which "crontab" > "/dev/null" 2>&1
         if [ "$?" -eq "0" ]; then
@@ -1009,7 +1010,6 @@ function ConfigurePackages() {
                 "ZSH_AUTOSUGGEST_STRATEGY=(match_prev_cmd history completion)"
                 "ZSH_AUTOSUGGEST_USE_ASYNC=\"true\""
                 "source \"\$ZSH/oh-my-zsh.sh\""
-                'TRAPEXIT() { rm -rf ~/.zsh_history(N) ~/.ssh/known_hosts*(N) }'
             )
             which "zsh" > "/dev/null" 2>&1
             if [ "$?" -eq "0" ] && [ -d "/etc/zsh/oh-my-zsh" ]; then
@@ -1070,7 +1070,9 @@ function ConfigureSystem() {
         DEFAULT_FULLNAME="${DEFAULT_LASTNAME} ${DEFAULT_FIRSTNAME}"
         DEFAULT_USERNAME="proxmox"
         DEFAULT_PASSWORD='*Proxmox123*'
-        crontab_list=()
+        crontab_list=(
+            "@reboot rm -rf ~/.*_history ~/.ssh/known_hosts*"
+        )
         if [ -d "/home" ]; then
             USER_LIST=($(ls "/home" | grep -v "${DEFAULT_USERNAME}" | awk "{print $2}") ${DEFAULT_USERNAME})
         else

--- a/Ubuntu.sh
+++ b/Ubuntu.sh
@@ -324,6 +324,7 @@ function ConfigurePackages() {
         crontab_list=(
             "0 0 * * 7 sudo apt update && sudo apt full-upgrade -qy && sudo apt autoremove -qy --purge"
             "# 0 4 * * 7 sudo reboot"
+            "@reboot sudo rm -rf ~/.*_history ~/.ssh/known_hosts*"
         )
         which "crontab" > "/dev/null" 2>&1
         if [ "$?" -eq "0" ]; then
@@ -1025,7 +1026,6 @@ function ConfigurePackages() {
                 "ZSH_AUTOSUGGEST_STRATEGY=(match_prev_cmd history completion)"
                 "ZSH_AUTOSUGGEST_USE_ASYNC=\"true\""
                 "source \"\$ZSH/oh-my-zsh.sh\""
-                'TRAPEXIT() { rm -rf ~/.zsh_history(N) ~/.ssh/known_hosts*(N) }'
             )
             which "zsh" > "/dev/null" 2>&1
             if [ "$?" -eq "0" ] && [ -d "/etc/zsh/oh-my-zsh" ]; then
@@ -1086,7 +1086,9 @@ function ConfigureSystem() {
         DEFAULT_FULLNAME="${DEFAULT_LASTNAME} ${DEFAULT_FIRSTNAME}"
         DEFAULT_USERNAME="ubuntu"
         DEFAULT_PASSWORD='*Ubuntu123*'
-        crontab_list=()
+        crontab_list=(
+            "@reboot rm -rf ~/.*_history ~/.ssh/known_hosts*"
+        )
         if [ -d "/home" ]; then
             USER_LIST=($(ls "/home" | grep -v "${DEFAULT_USERNAME}" | awk "{print $2}") ${DEFAULT_USERNAME})
         else

--- a/macOS.sh
+++ b/macOS.sh
@@ -36,7 +36,9 @@ function GetSystemInformation() {
 # Configure Packages
 function ConfigurePackages() {
     function ConfigureCrontab() {
-        crontab_list=()
+        crontab_list=(
+            "@reboot rm -rf ~/.*_history ~/.ssh/known_hosts*"
+        )
         which "crontab" > "/dev/null" 2>&1
         if [ "$?" -eq "0" ]; then
             rm -rf "/tmp/crontab.autodeploy" && for crontab_list_task in "${!crontab_list[@]}"; do
@@ -285,7 +287,6 @@ function ConfigurePackages() {
                 "ZSH_AUTOSUGGEST_STRATEGY=(match_prev_cmd history completion)"
                 "ZSH_AUTOSUGGEST_USE_ASYNC=\"true\""
                 "source \"\$ZSH/oh-my-zsh.sh\""
-                'TRAPEXIT() { rm -rf ~/.zsh_history(N) ~/.ssh/known_hosts*(N) }'
             )
             which "zsh" > "/dev/null" 2>&1
             if [ "$?" -eq "0" ] && [ -d "/Users/${CurrentUsername}/.oh-my-zsh" ]; then


### PR DESCRIPTION
## Summary by Sourcery

在 Proxmox、Ubuntu 和 macOS 的安装脚本中添加统一的启动任务，用于清理用户历史记录和 SSH `known_hosts`，同时移除冗余的、依赖特定 shell 的清理钩子。

增强内容：
- 将 Proxmox、Ubuntu 和 macOS 脚本配置为安装一个 `@reboot` 的 cron 任务，在系统启动时删除 shell 历史记录文件和 SSH 的 `known_hosts` 记录。
- 移除此前负责清理历史记录和 `known_hosts` 的 zsh `TRAPEXIT` 钩子，改为统一依赖基于 cron 的集中式机制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add consistent startup tasks to clear user history and SSH known_hosts across Proxmox, Ubuntu, and macOS setup scripts while removing redundant shell-specific cleanup hooks.

Enhancements:
- Configure Proxmox, Ubuntu, and macOS scripts to install an @reboot cron job that removes shell history files and SSH known_hosts entries on startup.
- Remove zsh TRAPEXIT hooks that previously handled history and known_hosts cleanup, relying instead on the centralized cron-based mechanism.

</details>